### PR TITLE
Adding additional method in ModelMatrix

### DIFF
--- a/modelmatrix-core/src/main/scala/com/collective/modelmatrix/ModelMatrix.scala
+++ b/modelmatrix-core/src/main/scala/com/collective/modelmatrix/ModelMatrix.scala
@@ -224,7 +224,7 @@ class ModelMatrix(sqlContext: SQLContext) extends ModelMatrixCatalogAccess with 
     name: Option[String],
     comment: Option[String],
     concurrencyLevel: Int
-  ): Int = {
+    ): Int = {
 
     log.info(s"Create new Model Matrix instance for definition: $modelDefinitionId. " +
       s"Name: $name. Comment: $comment. Concurrency: $concurrencyLevel")
@@ -267,4 +267,16 @@ class ModelMatrix(sqlContext: SQLContext) extends ModelMatrixCatalogAccess with 
     }
   }
 
+  /**
+   * Check if a model matrix definition id is present in the model matrix DB.
+   *
+   * @param mmDefinitionId model matrix definition id for which you want to verify the existence
+   * @return true if the model matrix definition id is valid else false
+   */
+  def isValidModelMatrixDefinition(mmDefinitionId: Int): Boolean = {
+    blockOn(db.run(modelDefinitions.findById(mmDefinitionId))) match {
+      case Some(_) => true
+      case None => false
+    }
+  }
 }


### PR DESCRIPTION
We want to be able to validate if a model matrix definition exists in the model matrix DB before we actually try to create an instance